### PR TITLE
make AirDrop windows friendly

### DIFF
--- a/lib/air-drop.js
+++ b/lib/air-drop.js
@@ -162,6 +162,7 @@ var packageMethods = {
         package.useCachedResult(key, fetchFunc, deliverSource(req, res));
       });
 
+      //@todo: should include path.name if provided
       app.get(package.url + "/require/:filepath", function(req, res) {
         var filepath = req.params.filepath.replace(/\|/g, "/"),
             key = package.packageName + "/require/" + filepath,
@@ -175,8 +176,13 @@ var packageMethods = {
   },
 
   _fetchCode: function(path, cb) {
-    var wrap = this._fetchWrappedFile();
-    glob(path.path, function(err, filePaths) {
+    var wrap = this._fetchWrappedFile(),
+
+        //glob does not support windows pattern "c:\\dir1\\dir2\\**" and must be changed to "c:/dir1/dir2/**"
+        //another point, glob does not support absolute path for windows (pull request sent to fix this issue)    
+        glob_path = process.platform === "win32" ? path.path.replace(/\\/g, '/') :path.path;
+
+    glob(glob_path, function(err, filePaths) {
       if(err) { return cb(err); }
       if(filePaths.length === 0) {
         return cb("No files found in path " + path.path);
@@ -200,6 +206,12 @@ var packageMethods = {
     else {
       return function(path, cb) {
         encodedPath = path.fetchPath.replace(/\//g, "|");
+
+        //if name given to path - eg: require('js/jquery-1.7.2.js', {name: 'jquery'})
+        //add path.name to src script
+        //@todo: add support to route url/require/filepath[/path_name] with internal router 
+        //    (already done in air-drop-flatiron)
+        if (path.name) encodedPath += "/"+path.name;
         cb(null, "document.write('<scr'+'ipt src=\"" + package.url + "/" + path.type + "/" + encodedPath + "\" type=\"text/javascript\"></scr'+'ipt>');");
       }
     }
@@ -250,7 +262,11 @@ function expandPaths(paths, cb) {
 }
 
 function expandPath(path, cb) {
-  glob(path.path, function(err, filePaths) {
+  //glob does not support windows pattern "c:\\dir1\\dir2\\**" and must be changed to "c:/dir1/dir2/**"
+  //another point, glob does not support absolute path for windows (I've sent a pull request to fix this issue)
+  var glob_path = process.platform === "win32" ? path.path.replace(/\\/g, '/') : path.path;
+
+  glob(glob_path, function(err, filePaths) {
     try {
       if(err) { throw err; }
       var clonedPaths = _(filePaths).map(function(newPath) {

--- a/lib/air-drop.js
+++ b/lib/air-drop.js
@@ -162,12 +162,14 @@ var packageMethods = {
         package.useCachedResult(key, fetchFunc, deliverSource(req, res));
       });
 
-      //@todo: should include path.name if provided
+      //@todo: routing should accept optional module_name param
+      //    eg: package.url + "/require/:filepath[/:module_name]" provided by path.name
       app.get(package.url + "/require/:filepath", function(req, res) {
         var filepath = req.params.filepath.replace(/\|/g, "/"),
+            // module_name = req.params.module_name || undefined
             key = package.packageName + "/require/" + filepath,
             fetchFunc = function(cb) {
-              var path = new Path({type: "require", path: filepath});
+              var path = new Path({type: "require", path: filepath /*,name: module_name */});
               readWrapFile(path, cb);
             };
         package.useCachedResult(key, fetchFunc, deliverSource(req, res));

--- a/lib/path.js
+++ b/lib/path.js
@@ -22,6 +22,11 @@ function Path(options) {
     this.relativePath = pathLib.relative(this.root, this.path);
   }
   this.fetchPath = pathLib.relative(process.cwd(), this.path);
+  
+  if (process.platform === "win32") {
+    this.fetchPath = this.fetchPath.replace(/\\/g, '/');
+  }
+
   this.options = options;
 };
 module.exports = Path;


### PR DESCRIPTION
## Current issues
### Windows

Currently, AirDrop is not working on windows because of path resolution `path.resolve` (nightmare on windows: path `c:/foo/bar` is resolved as `c:\\foo\\bar`) and it makes bad things on Path AirDrop module.

Second issue on windows is usage of glob.
glob wants input with forward-slach (accept `/foo/bar` and not `\\foo\\bar`). Still path resolution in AirDrop has to fix path before using glob.

Last, but not the least, glob is not working with windows absolute path (eg: `glob('c:/foo/bar')`).

I sent a pull request to glob to fix these issues.
### AirDrop

AirDrop accepts required module to be named:

``` javascript
// in your Node script
var package = AirDrop("my-package").require(__dirname + "/../node_modules/underscore/underscore.js", {name: "underscore"});

// in the browser
var _ = require("underscore");
```

But this only works if you use `.package()`. Otherwise option `{name: "foo"}` is ignored.
I've modified `_fetchCode` to send `path.name` when provided.

Actually I'm preparing a AirDropFlatiron module that is an AirDrop for flatiron (using director router and embed AirDrop as a broadway plugin) and already accept the module_name in url.

AirDrop internal routing should be changed accordingly as commented in the code.
