### PR TITLE
Fixed path.name so it works like it does in the readme

### DIFF
--- a/lib/air-drop.js
+++ b/lib/air-drop.js
@@ -162,8 +162,19 @@ var packageMethods = {
         var filepath = req.params.filepath.replace(/\|/g, "/"),
             key = package.packageName + "/include/" + filepath,
             fetchFunc = function(cb) {
-              var path = new Path({type: "include", path: filepath});
-              package.readWrapFile(path, cb);
+              var path = null;
+
+              for (var i = 0; i < package.paths.length; i++){
+                if (package.paths[i].relativePath === filepath){
+                  path = package.paths[i];
+                  break;
+                }
+              }
+
+              if (path === null){
+                var path = new Path({type: "include", path: filepath});
+              }
+              readWrapFile(path, cb);
             };
         package.useCachedResult(key, fetchFunc, deliverSource(req, res));
       });
@@ -175,8 +186,19 @@ var packageMethods = {
             // module_name = req.params.module_name || undefined
             key = package.packageName + "/require/" + filepath,
             fetchFunc = function(cb) {
-              var path = new Path({type: "require", path: filepath /*,name: module_name */});
-              package.readWrapFile(path, cb);
+              var path = null;
+
+              for (var i = 0; i < package.paths.length; i++){
+                if (package.paths[i].relativePath === filepath){
+                  path = package.paths[i];
+                  break;
+                }
+              }
+
+              if (path === null){
+                path = new Path({type: "require", path: filepath});
+              }
+              readWrapFile(path, cb);
             };
         package.useCachedResult(key, fetchFunc, deliverSource(req, res));
       });


### PR DESCRIPTION
I made it so that if you do air-drop.reqiuire({path: path, name: "myName"}), you require that script in the browser by doing require("myName"). Like it shows in the readme
