### PR TITLE
encodedPath detected as global

### DIFF
--- a/lib/air-drop.js
+++ b/lib/air-drop.js
@@ -224,7 +224,7 @@ var packageMethods = {
       package.readWrapFile(path, cb);
     }
     else {
-      encodedPath = path.relativePath.replace(/\//g, "|");
+      var encodedPath = path.relativePath.replace(/\//g, "|");
       if (package.isCss()) {
         cb(null, "@import url(\"" + package.url + "/" + path.type + "/" + encodedPath + "\");");
       } else {


### PR DESCRIPTION
Thanks to mocha.
It seems to be an unwanted declaration
